### PR TITLE
move research category query to helper (fixes mana bean crash)

### DIFF
--- a/src/main/java/mod/icarus/crimsonrevelations/item/CRItemKnowledgeScribingTools.java
+++ b/src/main/java/mod/icarus/crimsonrevelations/item/CRItemKnowledgeScribingTools.java
@@ -2,6 +2,7 @@ package mod.icarus.crimsonrevelations.item;
 
 import mod.icarus.crimsonrevelations.config.CRConfig;
 import mod.icarus.crimsonrevelations.init.CRRarities;
+import mod.icarus.crimsonrevelations.util.ResearchHelperNCR;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.item.EntityItem;
@@ -20,7 +21,6 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 import net.minecraftforge.common.IRarity;
-import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -28,17 +28,13 @@ import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.capabilities.IPlayerKnowledge;
 import thaumcraft.api.items.IScribeTools;
 import thaumcraft.api.items.ItemsTC;
-import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.api.research.ResearchCategory;
 import thaumcraft.client.fx.FXDispatcher;
 import thaumcraft.common.lib.SoundsTC;
-import thecodex6824.thaumcraftfix.api.research.ResearchCategoryTheorycraftFilter;
 
 import javax.annotation.Nullable;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 public class CRItemKnowledgeScribingTools extends CRItem implements IScribeTools {
     public CRItemKnowledgeScribingTools() {
@@ -75,7 +71,7 @@ public class CRItemKnowledgeScribingTools extends CRItem implements IScribeTools
     @Override
     public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
         ItemStack stack = player.getHeldItem(hand);
-        ResearchCategory[] categories = this.getResearchCategories();
+        ResearchCategory[] categories = ResearchHelperNCR.getResearchCategories();
         int observationProgress = IPlayerKnowledge.EnumKnowledgeType.OBSERVATION.getProgression();
         int theoryProgress = IPlayerKnowledge.EnumKnowledgeType.THEORY.getProgression();
 
@@ -116,23 +112,6 @@ public class CRItemKnowledgeScribingTools extends CRItem implements IScribeTools
             return new ActionResult<>(EnumActionResult.SUCCESS, stack);
         } else {
             return new ActionResult<>(EnumActionResult.FAIL, stack);
-        }
-    }
-
-    // Use Thaumcraft Fix's filter if it's also installed.
-    private ResearchCategory[] getResearchCategories() {
-        if (Loader.isModLoaded("thaumcraftfix")) {
-            return ResearchCategoryTheorycraftFilter.getAllowedTheorycraftCategories().toArray(new ResearchCategory[0]);
-        } else {
-            Set<ResearchCategory> categories = new HashSet<>();
-            categories.add(ResearchCategories.getResearchCategory("ALCHEMY"));
-            categories.add(ResearchCategories.getResearchCategory("ARTIFICE"));
-            categories.add(ResearchCategories.getResearchCategory("AUROMANCY"));
-            categories.add(ResearchCategories.getResearchCategory("BASICS"));
-            categories.add(ResearchCategories.getResearchCategory("GOLEMANCY"));
-            categories.add(ResearchCategories.getResearchCategory("INFUSION"));
-            categories.add(ResearchCategories.getResearchCategory("ELDRITCH"));
-            return categories.toArray(new ResearchCategory[0]);
         }
     }
 

--- a/src/main/java/mod/icarus/crimsonrevelations/item/CRItemManaBean.java
+++ b/src/main/java/mod/icarus/crimsonrevelations/item/CRItemManaBean.java
@@ -6,6 +6,7 @@ import mod.icarus.crimsonrevelations.config.CRConfigLists;
 import mod.icarus.crimsonrevelations.init.CRBlocks;
 import mod.icarus.crimsonrevelations.init.CRItems;
 import mod.icarus.crimsonrevelations.tile.CRTileManaPod;
+import mod.icarus.crimsonrevelations.util.ResearchHelperNCR;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLog;
 import net.minecraft.block.state.IBlockState;
@@ -37,7 +38,6 @@ import thaumcraft.api.aspects.IEssentiaContainerItem;
 import thaumcraft.api.blocks.BlocksTC;
 import thaumcraft.api.capabilities.IPlayerKnowledge;
 import thaumcraft.api.research.ResearchCategory;
-import thecodex6824.thaumcraftfix.api.research.ResearchCategoryTheorycraftFilter;
 
 import java.util.Random;
 
@@ -79,7 +79,7 @@ public class CRItemManaBean extends ItemFood implements IEssentiaContainerItem {
 
             // Chance for an eaten bean to grant theories and observations for research
             if (world.rand.nextDouble() <= CRConfig.general_settings.MANA_BEAN_RESEARCH_CHANCE) {
-                ResearchCategory[] rc = ResearchCategoryTheorycraftFilter.getAllowedTheorycraftCategories().toArray(new ResearchCategory[0]);
+                ResearchCategory[] rc = ResearchHelperNCR.getResearchCategories();
                 int oProg = IPlayerKnowledge.EnumKnowledgeType.OBSERVATION.getProgression();
                 int tProg = IPlayerKnowledge.EnumKnowledgeType.THEORY.getProgression();
 

--- a/src/main/java/mod/icarus/crimsonrevelations/item/CRItemPrimordialScribingTools.java
+++ b/src/main/java/mod/icarus/crimsonrevelations/item/CRItemPrimordialScribingTools.java
@@ -2,6 +2,7 @@ package mod.icarus.crimsonrevelations.item;
 
 import mod.icarus.crimsonrevelations.config.CRConfig;
 import mod.icarus.crimsonrevelations.init.CRSoundEvents;
+import mod.icarus.crimsonrevelations.util.ResearchHelperNCR;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
@@ -16,7 +17,6 @@ import net.minecraft.util.text.Style;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.relauncher.FMLLaunchHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -27,17 +27,13 @@ import thaumcraft.api.capabilities.IPlayerWarp.EnumWarpType;
 import thaumcraft.api.capabilities.ThaumcraftCapabilities;
 import thaumcraft.api.items.IScribeTools;
 import thaumcraft.api.items.ItemsTC;
-import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.api.research.ResearchCategory;
 import thaumcraft.client.fx.FXDispatcher;
 import thaumcraft.common.lib.potions.PotionWarpWard;
-import thecodex6824.thaumcraftfix.api.research.ResearchCategoryTheorycraftFilter;
 
 import javax.annotation.Nullable;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 public class CRItemPrimordialScribingTools extends CRItem implements IScribeTools {
     public CRItemPrimordialScribingTools() {
@@ -50,7 +46,7 @@ public class CRItemPrimordialScribingTools extends CRItem implements IScribeTool
     @Override
     public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
         ItemStack stack = player.getHeldItem(hand);
-        ResearchCategory[] categories = this.getResearchCategories();
+        ResearchCategory[] categories = ResearchHelperNCR.getResearchCategories();
         int observationProgress = IPlayerKnowledge.EnumKnowledgeType.OBSERVATION.getProgression();
         int theoryProgress = IPlayerKnowledge.EnumKnowledgeType.THEORY.getProgression();
         IPlayerWarp warp = ThaumcraftCapabilities.getWarp(player);
@@ -108,23 +104,6 @@ public class CRItemPrimordialScribingTools extends CRItem implements IScribeTool
             return new ActionResult<>(EnumActionResult.SUCCESS, stack);
         } else {
             return new ActionResult<>(EnumActionResult.FAIL, stack);
-        }
-    }
-
-    // Use Thaumcraft Fix's filter if it's also installed.
-    private ResearchCategory[] getResearchCategories() {
-        if (Loader.isModLoaded("thaumcraftfix")) {
-            return ResearchCategoryTheorycraftFilter.getAllowedTheorycraftCategories().toArray(new ResearchCategory[0]);
-        } else {
-            Set<ResearchCategory> categories = new HashSet<>();
-            categories.add(ResearchCategories.getResearchCategory("ALCHEMY"));
-            categories.add(ResearchCategories.getResearchCategory("ARTIFICE"));
-            categories.add(ResearchCategories.getResearchCategory("AUROMANCY"));
-            categories.add(ResearchCategories.getResearchCategory("BASICS"));
-            categories.add(ResearchCategories.getResearchCategory("GOLEMANCY"));
-            categories.add(ResearchCategories.getResearchCategory("INFUSION"));
-            categories.add(ResearchCategories.getResearchCategory("ELDRITCH"));
-            return categories.toArray(new ResearchCategory[0]);
         }
     }
 

--- a/src/main/java/mod/icarus/crimsonrevelations/util/ResearchHelperNCR.java
+++ b/src/main/java/mod/icarus/crimsonrevelations/util/ResearchHelperNCR.java
@@ -1,0 +1,30 @@
+package mod.icarus.crimsonrevelations.util;
+
+import net.minecraftforge.fml.common.Loader;
+import thaumcraft.api.research.ResearchCategories;
+import thaumcraft.api.research.ResearchCategory;
+import thecodex6824.thaumcraftfix.api.research.ResearchCategoryTheorycraftFilter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ResearchHelperNCR {
+    public static final boolean isThaumcraftFixLoaded = Loader.isModLoaded("thaumcraftfix");
+
+    public static ResearchCategory[] getResearchCategories() {
+        // Use Thaumcraft Fix's filter if it's also installed.
+        if (isThaumcraftFixLoaded) {
+            return ResearchCategoryTheorycraftFilter.getAllowedTheorycraftCategories().toArray(new ResearchCategory[0]);
+        } else {
+            Set<ResearchCategory> categories = new HashSet<>();
+            categories.add(ResearchCategories.getResearchCategory("ALCHEMY"));
+            categories.add(ResearchCategories.getResearchCategory("ARTIFICE"));
+            categories.add(ResearchCategories.getResearchCategory("AUROMANCY"));
+            categories.add(ResearchCategories.getResearchCategory("BASICS"));
+            categories.add(ResearchCategories.getResearchCategory("GOLEMANCY"));
+            categories.add(ResearchCategories.getResearchCategory("INFUSION"));
+            categories.add(ResearchCategories.getResearchCategory("ELDRITCH"));
+            return categories.toArray(new ResearchCategory[0]);
+        }
+    }
+}


### PR DESCRIPTION
Fixes the crash when eating mana beans when Thaumcraft Fix is not installed. Also moves the research category query to a helper method to reduce repeated code and allow other items to access the method.